### PR TITLE
Add exclude network functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ NetworkManager assigns a UUID to each network profile. These can be seen by
 running `nmcli conn`. The UUIDs of the trusted networks should be placed in a
 file. By default `nmtrust` will look for this file at
 `/usr/local/etc/trusted_networks`, however an alternative location may be
-provided using the `-f` option.
+provided using the `-t` option.
 
 If all of the current network connections are trusted, the trusted network file
 can be initiated with these values.
@@ -37,6 +37,19 @@ file.
   untrusted.
 * If there are no active network connections, `nmtrust` will report this.
 
+### Exclude Networks
+
+Network connections can be excluded from nmtrust as well.
+
+For example, if you have Docker installed, the Docker bridge network connection(s)
+needs to be excluded from the active network connections list. Otherwise, if you
+disconnect all other connections, `nmtrust` still thinks there are active connections
+despite that you are offline.
+
+The name of the network(s) that need to be excluded should be placed in
+`/usr/local/etc/excluded_networks`, however an alternative location may be provided
+using the `-e` option.
+
 ### Usage
 
 A unique exit code is returned for each of the four possible states.
@@ -51,7 +64,7 @@ Exit Code | State
 This allows the user to easily script `nmtrust` to only execute certain actions
 on certain types of networks. For example, you may have a network backup script
 `netbackup.sh` that is executed every hour by cron. However, you only want the
-script to run when you are connected solely to a network or networksthat you
+script to run when you are connected solely to a network or networks that you
 trust. This is easy to accomplish by creating a wrapper around `netbackup.sh`
 for cron to call.
 

--- a/nmtrust
+++ b/nmtrust
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+EXCLUDEFILE="/usr/local/etc/excluded_networks"
 TRUSTFILE="/usr/local/etc/trusted_networks"
 
 ###############################################################################
@@ -9,14 +10,21 @@ usage() {
 Determine if the current NetworkManager connections are trusted.
 
 Options:
-    -f      specify an alternative location for the trusted network file
+    -e      specify an alternative location for the excluded networks file
+    -t      specify an alternative location for the trusted networks file
     -q      be quiet"
 }
 
 file_check() {
+    if [ ! -f "$EXCLUDEFILE" ]; then
+        touch $EXCLUDEFILE
+        if [ "$quiet" != true ]; then
+            echo "Created empty excluded networks file: $EXCLUDEFILE"
+        fi
+    fi
     if [ ! -f "$TRUSTFILE" ]; then
         if [ "$quiet" != true ]; then
-            echo "Could not locate trusted network file: $TRUSTFILE"
+            echo "Could not locate trusted networks file: $TRUSTFILE"
         fi
         exit 1
     fi
@@ -50,9 +58,12 @@ no_network() {
     exit 4
 }
 
-while getopts ":f:qh" opt; do
+while getopts ":e:t:qh" opt; do
     case $opt in
-        f)
+        e)
+            EXCLUDEFILE=$OPTARG
+            ;;
+        t)
             TRUSTFILE=$OPTARG
             ;;
         q)
@@ -70,26 +81,31 @@ while getopts ":f:qh" opt; do
     esac
 done
 
-# Check if the trusted network file exists.
+# Check if the excluded and trusted networks files exist.
 file_check
 
 # Get all active connections.
-connections=($(nmcli --terse -f uuid conn show --active))
+connections=($(nmcli --terse -f name,uuid conn show --active))
+
+# Get number of active connections.
+num_connections=$(comm -13 <(sort "$EXCLUDEFILE") <(nmcli --terse -f name conn show --active | sort) | wc -l)
 
 # Get number of trusted connections.
 num_trusted=$(comm -12 <(nmcli --terse -f uuid conn show --active | sort) <(sort "$TRUSTFILE") | wc -l)
 
 # Determine if there are active connections.
-if [ ${#connections[@]} -eq 0 ]; then
+if [ $num_connections -eq 0 ]; then
     no_network
 # Check if any of the active connections are untrusted.
 elif [[ $num_trusted -eq 0 ]]; then
     all_untrusted
 else
-    for uuid in "${connections[@]}"; do
-        if ! grep -q ^"$uuid"$ "$TRUSTFILE"; then
-            num_untrusted=$((${#connections[@]} - num_trusted))
-            untrusted "$num_untrusted of ${#connections[@]}"
+    for connection in "${connections[@]}"; do
+        name=$(echo "$connection" | awk -F ":" '{print $1}')
+        uuid=$(echo "$connection" | awk -F ":" '{print $2}')
+        if ! grep -q ^"$name"$ "$EXCLUDEFILE" && ! grep -q ^"$uuid"$ "$TRUSTFILE"; then
+            num_untrusted=$((num_connections - num_trusted))
+            untrusted "$num_untrusted of $num_connections"
         fi
     done
 fi


### PR DESCRIPTION
nmtrust's "offline detection" doesn't work if there are active network
connections that are active all the time and only provide "internal
connectivity" like the Docker bridge connections.

Add configuration file for networks that should be excluded and count
active connections with `num_connections`.

Use options `-e` and `-t` to specify alternative file locations.