### PR TITLE
Update grep command to generate TRUSTED_UNITS

### DIFF
--- a/ttoggle
+++ b/ttoggle
@@ -39,7 +39,7 @@ extract_user() {
 }
 
 get_trusted_units() {
-    TRUSTED_UNITS=$(grep -v ',.*user:' "$UNITFILE" | cut -d ',' -f1)
+    TRUSTED_UNITS=$(grep -v '^#\|,.*user:' "$UNITFILE" | cut -d ',' -f1)
     OFFLINE_UNITS=$(grep ',.*allow_offline' "$UNITFILE" | grep -v ',.*user:' | cut -d ',' -f1)
 }
 


### PR DESCRIPTION
Allow lines starting with # in the trusted units file.

I want to use ```# Ansible Managed``` at the top. Without this fix, ttoggle shows:

```
# ttoggle
All connections are trusted
Starting trusted system units
Invalid unit name "#" escaped as "\x23" (maybe you should use systemd-escape?).
Failed to start \x23.service: Unit \x23.service not found.
Failed to start Ansible.service: Unit Ansible.service not found.
Failed to start Managed.service: Unit Managed.service not found.
Starting trusted user units
```