### PR TITLE
Wildcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ The name of the network(s) that need to be excluded should be placed in
 `/etc/nmtrust/excluded_networks`, however an alternative location may be
 provided using the `-e` option.
 
+You can place the exact names in the file or you can use wildcards to exclude multiple
+networks. For example, `virbr0`, `virbr1`, etc. pp. or just `virbr?`. You can also
+specify a range: `virbr[0,1]`.
+
 ### Usage
 
 A unique exit code is returned for each of the four possible states.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nmtrust
 
-This project provides a simple framework for determing the trusted state of the
+This project provides a simple framework for determining the trusted state of the
 current network connections, and taking action based on the result. It is
 intended to be used to activate certain services on trusted networks, and
 disable them when when there is a connection to an untrusted network or when

--- a/nmtrust
+++ b/nmtrust
@@ -45,6 +45,19 @@ file_check() {
     fi
 }
 
+check_connection() {
+    local name=$1
+    local connection_excluded=false
+    local excludes=($(grep -v '^#' < $EXCLUDEFILE))
+    for exclude in "${excludes[@]}"; do
+        if [[ "$name" == $exclude ]]; then
+            connection_excluded=true
+            break
+        fi
+    done
+    echo $connection_excluded
+}
+
 trusted() {
     message "All connections are trusted"
     exit 0
@@ -95,7 +108,13 @@ file_check
 mapfile -t connections < <(nmcli --terse -f name,uuid conn show --active)
 
 # Get number of active connections.
-num_connections=$(comm -13 <(sort "$EXCLUDEFILE") <(nmcli --terse -f name conn show --active | sort) | wc -l)
+num_connections=0
+for connection in "${connections[@]}"; do
+    name=$(echo "$connection" | awk -F ":" '{print $1}')
+    if [[ $(check_connection $name) = false ]]; then
+        ((num_connections++))
+    fi
+done
 
 # Get number of trusted connections.
 num_trusted=$(comm -12 <(nmcli --terse -f uuid conn show --active | sort) <(sort "$TRUSTFILE") | wc -l)
@@ -110,7 +129,7 @@ else
     for connection in "${connections[@]}"; do
         name=$(echo "$connection" | awk -F ":" '{print $1}')
         uuid=$(echo "$connection" | awk -F ":" '{print $2}')
-        if ! grep -q ^"$name"$ "$EXCLUDEFILE" && ! grep -q ^"$uuid"$ "$TRUSTFILE"; then
+        if [[ $(check_connection $name) = false ]] && ! grep -q ^"$uuid"$ "$TRUSTFILE"; then
             num_untrusted=$((num_connections - num_trusted))
             untrusted "$num_untrusted of $num_connections"
         fi


### PR DESCRIPTION
I use docker and libvirt and especially libvirt creates multiple brides (`virbr0`, `virbr1`, etc. pp.) and for each VM that's connected to those bridges a `vnet` device will be created. 

Instead of using..
```
docker0
virbr0
virbr1
vnet0
vnet1
vnet2
...
```
.. I just have to use..
```
docker?
virbr?
vnet?
```
..and don't have add new `vnet` adapters every time.