### PR TITLE
Improve nmtrust and ttogle output

### DIFF
--- a/nmtrust
+++ b/nmtrust
@@ -96,7 +96,7 @@ list_connections() {
 }
 
 trusted() {
-    message "All connections are trusted"
+    message "${GREEN}All connections are trusted${NORMAL}"
     if [ "$verbose" == true ]; then
         echo
         list_connections
@@ -105,7 +105,7 @@ trusted() {
 }
 
 all_untrusted() {
-    message "All connections are untrusted"
+    message "${RED}All connections are untrusted${NORMAL}"
     if [ "$verbose" == true ]; then
         echo
         list_connections
@@ -114,7 +114,7 @@ all_untrusted() {
 }
 
 untrusted() {
-    message "${1-One or more} connections are untrusted"
+    message "${RED}${1-One or more} connections are untrusted${NORMAL}"
     if [ "$verbose" == true ]; then
         echo
         list_connections
@@ -123,7 +123,7 @@ untrusted() {
 }
 
 no_network() {
-    message "There are no active connections"
+    message "${YELLOW}There are no active connections${NORMAL}"
     exit 4
 }
 

--- a/nmtrust
+++ b/nmtrust
@@ -67,6 +67,7 @@ check_connection() {
     local connection_excluded=false
     mapfile -t excludes < <(grep -v '^#' < $EXCLUDEFILE)
     for exclude in "${excludes[@]}"; do
+        # NOTE: Cannot quote right-hand site of == because glob matching is needed [shellcheck(SC2053)]
         if [[ "$name" == $exclude ]]; then
             connection_excluded=true
             break

--- a/nmtrust
+++ b/nmtrust
@@ -5,6 +5,22 @@ TRUSTFILE="/etc/nmtrust/trusted_networks"
 
 ###############################################################################
 
+# Use colors, but only if connected to a terminal, and that terminal supports them.
+if which tput >/dev/null 2>&1; then
+  ncolors=$(tput colors)
+fi
+if [ -t 1 ] && [ -n "$ncolors" ] && [ "$ncolors" -ge 8 ]; then
+  RED="$(tput setaf 1)"
+  GREEN="$(tput setaf 2)"
+  YELLOW="$(tput setaf 3)"
+  NORMAL="$(tput sgr0)"
+else
+  RED=""
+  GREEN=""
+  YELLOW=""
+  NORMAL=""
+fi
+
 usage() {
     echo "Usage: nmtrust [OPTION...]
 Determine if the current NetworkManager connections are trusted.
@@ -69,11 +85,11 @@ list_connections() {
         name=$(echo "${connections[$i-1]}" | awk -F ":" '{print $1}')
         uuid=$(echo "${connections[$i-1]}" | awk -F ":" '{print $2}')
         if grep -q "$uuid" "$TRUSTFILE"; then
-        echo "${nmcli[$i]}trusted"
+        echo "${GREEN}${nmcli[$i]}trusted${NORMAL}"
         elif [[ $(check_connection "$name") = true ]]; then
-        echo "${nmcli[$i]}excluded"
+        echo "${GREEN}${nmcli[$i]}excluded${NORMAL}"
         else
-        echo "${nmcli[$i]}untrusted"
+        echo "${RED}${nmcli[$i]}untrusted${NORMAL}"
         fi
     fi
     done

--- a/nmtrust
+++ b/nmtrust
@@ -127,7 +127,7 @@ no_network() {
     exit 4
 }
 
-while getopts ":e:t:q:vh" opt; do
+while getopts ":e:t:qvh" opt; do
     case $opt in
         e)
             EXCLUDEFILE=$OPTARG

--- a/nmtrust
+++ b/nmtrust
@@ -12,7 +12,8 @@ Determine if the current NetworkManager connections are trusted.
 Options:
     -e      specify an alternative location for the excluded networks file
     -t      specify an alternative location for the trusted networks file
-    -q      be quiet"
+    -q      be quiet
+    -v      be verbose"
 }
 
 message() {
@@ -58,18 +59,50 @@ check_connection() {
     echo $connection_excluded
 }
 
+list_connections() {
+    mapfile -t nmcli < <(nmcli conn show --active)
+
+    for (( i=0; i<${#nmcli[@]}; i++ )); do
+    if [ "$i" -eq 0 ]; then
+        echo "${nmcli[$i]}STATUS"
+    else
+        name=$(echo "${connections[$i-1]}" | awk -F ":" '{print $1}')
+        uuid=$(echo "${connections[$i-1]}" | awk -F ":" '{print $2}')
+        if grep -q "$uuid" "$TRUSTFILE"; then
+        echo "${nmcli[$i]}trusted"
+        elif [[ $(check_connection "$name") = true ]]; then
+        echo "${nmcli[$i]}excluded"
+        else
+        echo "${nmcli[$i]}untrusted"
+        fi
+    fi
+    done
+}
+
 trusted() {
     message "All connections are trusted"
+    if [ "$verbose" == true ]; then
+        echo
+        list_connections
+    fi
     exit 0
 }
 
 all_untrusted() {
     message "All connections are untrusted"
+    if [ "$verbose" == true ]; then
+        echo
+        list_connections
+    fi
     exit 2
 }
 
 untrusted() {
     message "${1-One or more} connections are untrusted"
+    if [ "$verbose" == true ]; then
+        echo
+        list_connections
+    fi
     exit 3
 }
 
@@ -78,7 +111,7 @@ no_network() {
     exit 4
 }
 
-while getopts ":e:t:qh" opt; do
+while getopts ":e:t:q:vh" opt; do
     case $opt in
         e)
             EXCLUDEFILE=$OPTARG
@@ -88,6 +121,9 @@ while getopts ":e:t:qh" opt; do
             ;;
         q)
             quiet=true
+            ;;
+        v)
+            verbose=true
             ;;
         :)
             echo "Option -$OPTARG requires an argument."

--- a/nmtrust
+++ b/nmtrust
@@ -163,7 +163,7 @@ mapfile -t connections < <(nmcli --terse -f name,uuid conn show --active)
 num_connections=0
 for connection in "${connections[@]}"; do
     name=$(echo "$connection" | awk -F ":" '{print $1}')
-    if [[ $(check_connection $name) = false ]]; then
+    if [[ $(check_connection "$name") = false ]]; then
         ((num_connections++))
     fi
 done
@@ -172,16 +172,16 @@ done
 num_trusted=$(comm -12 <(nmcli --terse -f uuid conn show --active | sort) <(sort "$TRUSTFILE") | wc -l)
 
 # Determine if there are active connections.
-if [ $num_connections -eq 0 ]; then
+if [ "$num_connections" -eq 0 ]; then
     no_network
 # Check if any of the active connections are untrusted.
-elif [[ $num_trusted -eq 0 ]]; then
+elif [[ "$num_trusted" -eq 0 ]]; then
     all_untrusted
 else
     for connection in "${connections[@]}"; do
         name=$(echo "$connection" | awk -F ":" '{print $1}')
         uuid=$(echo "$connection" | awk -F ":" '{print $2}')
-        if [[ $(check_connection $name) = false ]] && ! grep -q ^"$uuid"$ "$TRUSTFILE"; then
+        if [[ $(check_connection "$name") = false ]] && ! grep -q ^"$uuid"$ "$TRUSTFILE"; then
             num_untrusted=$((num_connections - num_trusted))
             untrusted "$num_untrusted of $num_connections"
         fi

--- a/ttoggle
+++ b/ttoggle
@@ -65,7 +65,7 @@ start() {
         if [ "$quiet" != true ]; then
             echo "Starting trusted system units"
         fi
-        systemctl start $TRUSTED_SYSTEM_UNITS
+        systemctl start "$TRUSTED_SYSTEM_UNITS"
     fi
     if [ -n "$TRUSTED_USER_UNITS" ]; then
         if [ "$quiet" != true ]; then
@@ -82,7 +82,7 @@ stop() {
         if [ "$quiet" != true ]; then
             echo "Stopping trusted system units"
         fi
-        systemctl stop $TRUSTED_SYSTEM_UNITS
+        systemctl stop "$TRUSTED_SYSTEM_UNITS"
     fi
     if [ -n "$TRUSTED_USER_UNITS" ]; then
         if [ "$quiet" != true ]; then
@@ -100,7 +100,7 @@ start_offline() {
         if [ "$quiet" != true ]; then
             echo "Starting trusted system offline units"
         fi
-        systemctl start $OFFLINE_SYSTEM_UNITS
+        systemctl start "$OFFLINE_SYSTEM_UNITS"
     fi
     if [ -n "$OFFLINE_USER_UNITS" ]; then
         if [ "$quiet" != true ]; then
@@ -116,7 +116,7 @@ status() {
     echo "Systemd system units:"
     for unit in $TRUSTED_SYSTEM_UNITS
     do
-        SYSTEMD_COLORS=1 systemctl status $unit | sed '1p;/^\s*Active:/!d'
+        SYSTEMD_COLORS=1 systemctl status "$unit" | sed '1p;/^\s*Active:/!d'
     done
     echo "Systemd user units:"
     echo "$TRUSTED_USER_UNITS" | while read -r line; do
@@ -141,14 +141,14 @@ while getopts ":f:sxtqh" opt; do
         t)
             startall=true
             ;;
-        h | *)
-            usage
-            exit
-            ;;
         :)
             echo "Option -$OPTARG requires an argument."
             usage
             exit 1
+            ;;
+        h | *)
+            usage
+            exit
             ;;
     esac
 done

--- a/ttoggle
+++ b/ttoggle
@@ -49,7 +49,7 @@ user_toggle() {
     unit_user=$(extract_user "$line")
     unit=$(echo "$line" | cut -d ',' -f1)
     if [ "$1" = "status" ]; then
-        command="systemctl $1 --user $unit | grep '^\s*Active\|●'"
+        command="systemctl $1 --user $unit | sed '1p;/^\s*Active:/!d'"
     else
         command="systemctl $1 --user $unit"
     fi
@@ -113,7 +113,10 @@ start_offline() {
 }
 
 status() {
-    systemctl status $TRUSTED_SYSTEM_UNITS | grep '^\s*Active\|●'
+    for unit in $TRUSTED_SYSTEM_UNITS
+    do
+        systemctl status $unit | sed '1p;/^\s*Active:/!d'
+    done
     echo "$TRUSTED_USER_UNITS" | while read -r line; do
         user_toggle "status" "$line"
     done

--- a/ttoggle
+++ b/ttoggle
@@ -113,10 +113,12 @@ start_offline() {
 }
 
 status() {
+    echo "Systemd system units:"
     for unit in $TRUSTED_SYSTEM_UNITS
     do
         SYSTEMD_COLORS=1 systemctl status $unit | sed '1p;/^\s*Active:/!d'
     done
+    echo "Systemd user units:"
     echo "$TRUSTED_USER_UNITS" | while read -r line; do
         user_toggle "status" "$line"
     done

--- a/ttoggle
+++ b/ttoggle
@@ -49,7 +49,7 @@ user_toggle() {
     unit_user=$(extract_user "$line")
     unit=$(echo "$line" | cut -d ',' -f1)
     if [ "$1" = "status" ]; then
-        command="systemctl $1 --user $unit | sed '1p;/^\s*Active:/!d'"
+        command="SYSTEMD_COLORS=1 systemctl $1 --user $unit | sed '1p;/^\s*Active:/!d'"
     else
         command="systemctl $1 --user $unit"
     fi
@@ -115,7 +115,7 @@ start_offline() {
 status() {
     for unit in $TRUSTED_SYSTEM_UNITS
     do
-        systemctl status $unit | sed '1p;/^\s*Active:/!d'
+        SYSTEMD_COLORS=1 systemctl status $unit | sed '1p;/^\s*Active:/!d'
     done
     echo "$TRUSTED_USER_UNITS" | while read -r line; do
         user_toggle "status" "$line"


### PR DESCRIPTION
I move between several locations with trusted and untrusted networks and I also use Docker, Virtualbox, and libvirtd. I find it helpful to have a nmtrust verbose output which gives me an overview of the connection status. This makes it easier for me to find out why my services are not running because of some (new) untrusted connections.

nmtrust verbose output with status for each active connection and colored output:
```
All connections are trusted

NAME                       UUID                                  TYPE    DEVICE          STATUS
Chris's iPhone 12 Pro Max  cbb1b5c2-6fd9-4f36-abfa-230ff9d40414  wifi    wlp2s0          trusted
br-8e15dbfdbac6            72ed7fa2-ff31-4048-a547-b1558a9ce4ce  bridge  br-8e15dbfdbac6 excluded
br-4d9297e3e7cb            067e32ec-7c6a-4ddc-a83e-f702500a2c41  bridge  br-4d9297e3e7cb excluded
docker0                    a0cf5500-0751-40fc-a421-441c7c644d59  bridge  docker0         excluded
virbr0                     038e2525-acad-4c6c-9ef3-047d7b5dfd38  bridge  virbr0          excluded
```

You can remove the colors from the normal nmtrust output if it's too much, but I would like to keep it for the verbose output.

The ttoggle status output doesn't show the unit names if a unit isn't started (see commit message for more detail).

ttoggle status with systemd colors:
```
Systemd system units:
● tor.service - Anonymizing overlay network for TCP
     Active: active (running) since Sun 2022-06-26 07:36:45 +07; 10min ago
× localtime.service - Timezone Updater Daemon
     Active: failed (Result: exit-code) since Sun 2022-06-26 07:36:46 +07; 10min ago
● roothints.timer - Unbound Root Hints Update Timer
     Active: active (waiting) since Sun 2022-06-26 07:36:45 +07; 10min ago
Systemd user units:
● syncthing.service - Syncthing - Open Source Continuous File Synchronization
     Active: active (running) since Sun 2022-06-26 07:36:45 +07; 10min ago
```