### PR TITLE
fix: exclude wireguard with loopback

### DIFF
--- a/nmtrust
+++ b/nmtrust
@@ -158,7 +158,7 @@ done
 file_check
 
 # Get all active connections.
-mapfile -t connections < <(nmcli --terse -f name,uuid,type conn show --active | grep -v loopback)
+mapfile -t connections < <(nmcli --terse -f name,uuid,type conn show --active | grep -E -v '(loopback|wiregard)')
 
 # Get number of active connections.
 num_connections=0
@@ -170,7 +170,7 @@ for connection in "${connections[@]}"; do
 done
 
 # Get number of trusted connections.
-num_trusted=$(comm -12 <(nmcli --terse -f uuid,type conn show --active | grep -v loopback | sed -e 's/:.*$//' | sort) <(sort "$TRUSTFILE") | wc -l)
+num_trusted=$(comm -12 <(nmcli --terse -f uuid,type conn show --active | grep -E -v ('loopback|wireguard') | sed -e 's/:.*$//' | sort) <(sort "$TRUSTFILE") | wc -l)
 
 # Determine if there are active connections.
 if [ "$num_connections" -eq 0 ]; then


### PR DESCRIPTION
Hi,
I realize we should ignore wireguard connection, as they are always "up" compared to "openvpn" when no network (wifi, ethernet).
With this patch the behavior looks more logic and functonnial compared to before.
This suppose we considere all our wireguard connection as trusted, this make sense to me.
I can also just use networks_excluded... 